### PR TITLE
add option to convert errors to warnings

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,9 @@ module.exports =
       type: 'array'
       default: []
       description: 'For a list of code visit http://pep8.readthedocs.org/en/latest/intro.html#error-codes'
+    convertAllErrorsToWarnings:
+      type: 'boolean'
+      default: false
 
   activate: ->
 
@@ -34,7 +37,7 @@ module.exports =
             line = parseInt(match[1]) or 0
             col = parseInt(match[2]) or 0
             toReturn.push({
-              type: "Error"
+              type: if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
               text: match[3]
               filePath
               range: [[line - 1, col - 1], [line - 1, col]]

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,7 +12,7 @@ module.exports =
       description: 'For a list of code visit http://pep8.readthedocs.org/en/latest/intro.html#error-codes'
     convertAllErrorsToWarnings:
       type: 'boolean'
-      default: false
+      default: true
 
   activate: ->
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -30,6 +30,7 @@ module.exports =
         if ignoreCodes = atom.config.get('linter-pep8.ignoreErrorCodes')
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
         parameters.push('-')
+        msgtype = if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
         return helpers.exec(atom.config.get('linter-pep8.pep8ExecutablePath'), parameters, {stdin: textEditor.getText()}).then (result) ->
           toReturn = []
           regex = /stdin:(\d+):(\d+):(.*)/g
@@ -37,7 +38,7 @@ module.exports =
             line = parseInt(match[1]) or 0
             col = parseInt(match[2]) or 0
             toReturn.push({
-              type: if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
+              type: msgtype
               text: match[3]
               filePath
               range: [[line - 1, col - 1], [line - 1, col]]


### PR DESCRIPTION
This just adds an extra option that allows pep8 "errors" to be converted to warnings.

The idea here is that many (all?) of PEP8's errors are actually style *suggestions*.  After all, the first section of the PEP8 document is titled "A Foolish Consistency is the Hobgoblin of Little Minds".  I find it much more helpful to combine a proper linter giving errors with PEP8 giving warnings.