### PR TITLE
Add fix-path option.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,8 +13,15 @@ module.exports =
     convertAllErrorsToWarnings:
       type: 'boolean'
       default: true
+    enableFixPath:
+      type: 'boolean'
+      title: 'Enable fix-path'
+      description: 'Fix the `$PATH` on OS X when Atom is run from a GUI app.'
+      default: process.platform is 'darwin'
 
   activate: ->
+    # can not reverse fix-path once loaded
+    require('fix-path')() if atom.config.get('linter-pep8.enableFixPath')
 
   provideLinter: ->
     helpers = require('atom-linter')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^1.0.0"
+    "atom-linter": "^1.0.0",
+    "fix-path": "^1.0.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
On OS X electron frequently does not seem to pick up the PATH setting
correctly when launching Atom from a GUI, for example the Dock. This
means that pep8 can not be found. One workaround is to specify the
absolute path to pep8, but this can be done automatically. This
provides a much better experience for users on OS X.

- Adds `enableFixPath` option.
- Defaults `enableFixPath` to true for 'darwin` (OS X) platform.
- Provides user documentation for option, indicating its use in OS X.
- Adds `fix-path` dependency.