### PR TITLE
Provide linter name so it won't be "Unnamed linter" in editor

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,6 +19,7 @@ module.exports =
   provideLinter: ->
     helpers = require('atom-linter')
     provider =
+      name: 'pep8'
       grammarScopes: ['source.python']
       scope: 'file' # or 'project'
       lintOnFly: true # must be false for scope: 'project'


### PR DESCRIPTION
This fixes #32