### PR TITLE
Force EOL to be LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 node_modules
 .idea
+.github_changelog_generator


### PR DESCRIPTION
* Force git to checkout the files with LF EOL on all platforms.
* Adds a .editorconfig file to default compatible editors to this setting if they weren't already.
* Add ignoring the changelog generator config.