### PR TITLE
Read pep8 config by using filename instead of stdin

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,11 +33,11 @@ module.exports =
           parameters.push("--max-line-length=#{maxLineLength}")
         if ignoreCodes = atom.config.get('linter-pep8.ignoreErrorCodes')
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
-        parameters.push('-')
+        parameters.push(filePath)
         msgtype = if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
-        return helpers.exec(atom.config.get('linter-pep8.pep8ExecutablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
+        return helpers.exec(atom.config.get('linter-pep8.pep8ExecutablePath'), parameters, {ignoreExitCode: true}).then (result) ->
           toReturn = []
-          regex = /stdin:(\d+):(\d+):(.*)/g
+          regex = /[^:]+:(\d+):(\d+):(.*)/g
           while (match = regex.exec(result)) isnt null
             line = parseInt(match[1]) or 0
             col = parseInt(match[2]) or 0


### PR DESCRIPTION
pep8 automatically looks for config files in parent directories of the files you give it. This obviously does not work when passing the content of the editor by stdin, which is what `linter-pep8` does.

Now I don't know if atomlinter plugins should always read from stdin, so that unsaved files can be linted too. This PR definitely breaks that.

However using config files is interesting as some people have special pep8 settings they want to use, and this plugin is a very prominent case of not adhering to config files.