### PR TITLE
pycodestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # linter-pep8
 
 This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides
-an interface to [pep8](https://pypi.python.org/pypi/pep8). It will be used
+an interface to [pycodestyle](https://pypi.python.org/pypi/pycodestyle). It will be used
 with Python files.
 
 ## Installation
@@ -9,16 +9,16 @@ with Python files.
 Linter package must be installed in order to use this plugin. If Linter is not
 installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
 
-### pep8 installation
+### pycodestyle installation
 
-Before using this plugin, you must ensure that `pep8` is installed on your
-system. To install `pep8`, do the following:
+Before using this plugin, you must ensure that `pycodestyle` is installed on your
+system. To install `pycodestyle`, do the following:
 
-Install [pep8](https://pypi.python.org/pypi/pep8) by typing the following in a
+Install [pycodestyle](https://pypi.python.org/pypi/pycodestyle) by typing the following in a
 terminal:
 
 ```ShellSession
-pip install pep8
+pip install pycodestyle
 ```
 
 Now you can proceed to install the linter-pep8 plugin.
@@ -33,14 +33,14 @@ Now you can proceed to install the linter-pep8 plugin.
 
 You can configure linter-pep8 from the settings menu:
 
-*   **pep8ExecutablePath** Path to your pep8 executable. This is useful if you
+*   **pycodestyleExecutablePath** Path to your pycodestyle executable. This is useful if you
     have different versions of pylint for Python 2 and 3 or if you are using a
     virtualenv
 
 *   **maxLineLength** The max line length for your python code, defaults to 79
 
-*   **ignoreErrorCodes** A list of pep8 error codes to ignore. For a list of
-    code visit <http://pep8.readthedocs.org/en/latest/intro.html#error-codes>
+*   **ignoreErrorCodes** A list of pycodestyle error codes to ignore. For a list of
+    code visit <http://pycodestyle.readthedocs.org/en/latest/intro.html#error-codes>
 
     Example: To ignore `W191` and `E501` you would enter something like this:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Now you can proceed to install the linter-pep8 plugin.
 
 You can configure linter-pep8 from the settings menu:
 
-*   **pycodestyleExecutablePath** Path to your pycodestyle executable. This is useful if you
+*   **executablePath** Path to your pycodestyle executable. This is useful if you
     have different versions of pylint for Python 2 and 3 or if you are using a
     virtualenv
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,16 +2,16 @@ helpers = null
 
 module.exports =
   config:
-    pep8ExecutablePath:
+    pycodestyleExecutablePath:
       type: 'string'
-      default: 'pep8'
+      default: 'pycodestyle'
     maxLineLength:
       type: 'integer'
       default: 0
     ignoreErrorCodes:
       type: 'array'
       default: []
-      description: 'For a list of code visit http://pep8.readthedocs.org/en/latest/intro.html#error-codes'
+      description: 'For a list of code visit http://pycodestyle.readthedocs.org/en/latest/intro.html#error-codes'
     convertAllErrorsToWarnings:
       type: 'boolean'
       default: true
@@ -21,7 +21,7 @@ module.exports =
 
   provideLinter: ->
     provider =
-      name: 'pep8'
+      name: 'pycodestyle'
       grammarScopes: ['source.python', 'source.python.django']
       scope: 'file' # or 'project'
       lintOnFly: true # must be false for scope: 'project'
@@ -35,7 +35,7 @@ module.exports =
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
         parameters.push('-')
         msgtype = if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
-        return helpers.exec(atom.config.get('linter-pep8.pep8ExecutablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
+        return helpers.exec(atom.config.get('linter-pep8.pycodestyleExecutablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
           toReturn = []
           regex = /stdin:(\d+):(\d+):(.*)/g
           while (match = regex.exec(result)) isnt null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,7 +2,7 @@ helpers = null
 
 module.exports =
   config:
-    pycodestyleExecutablePath:
+    executablePath:
       type: 'string'
       default: 'pycodestyle'
     maxLineLength:
@@ -35,7 +35,7 @@ module.exports =
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
         parameters.push('-')
         msgtype = if atom.config.get('linter-pep8.convertAllErrorsToWarnings') then 'Warning' else 'Error'
-        return helpers.exec(atom.config.get('linter-pep8.pycodestyleExecutablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
+        return helpers.exec(atom.config.get('linter-pep8.executablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
           toReturn = []
           regex = /stdin:(\d+):(\d+):(.*)/g
           while (match = regex.exec(result)) isnt null

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-pep8",
   "main": "./lib/main",
   "version": "1.3.2",
-  "description": "Linter plugin for pep8",
+  "description": "Linter plugin for pycodestyle",
   "repository": "https://github.com/AtomLinter/linter-pep8",
   "license": "MIT",
   "engines": {
@@ -26,6 +26,7 @@
     "atom",
     "python",
     "linter",
-    "pep8"
+    "pep8",
+    "pycodestyle"
   ]
 }


### PR DESCRIPTION
Changes the style guide from `pep8` to `pycodestyle`. I don't know how you all style your changelog, so I didn't touch that. However, I did increment the version in the package description to 1.4.0 because I felt it was appropriate according to semantic versioning. 

I tested this version on my computer, and it appeared to function correctly. `coffeelint` returned 3 errors: lines 14, 37, and 38 are too long, but there isn't a good place to break them.

The pull request addresses #55.
